### PR TITLE
fix: software.amazon.awssdk/netty-nio-client should be up, to fix vulnerability CVE-2025-24970

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <version.lambda-core>1.2.3</version.lambda-core>
         <version.lambda-events>3.15.0</version.lambda-events>
         <version.lambda-awssdk>2.31.2</version.lambda-awssdk>
-        <version.dynamodb>2.31.2</version.dynamodb>
+        <version.dynamodb>2.31.9</version.dynamodb>
         <version.jose4j>0.9.6</version.jose4j>
         <version.logback>1.5.18</version.logback>
         <version.maven-shade>3.2.4</version.maven-shade>


### PR DESCRIPTION
Up version of software.amazon.awssdk/netty-nio-client to fix vulnerability CVE-2025-24970 in subdependencies.