### PR TITLE
Update JwtVerifyMiddleware to handle VerificationException

### DIFF
--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/security/JwtVerifyMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/security/JwtVerifyMiddleware.java
@@ -210,9 +210,20 @@ public class JwtVerifyMiddleware implements MiddlewareHandler {
 
                     } catch (MalformedClaimException e) {
                         LOG.error("MalformedClaimException", e);
+                        
                         if (LOG.isDebugEnabled())
                             LOG.debug("JwtVerifyHandler.execute ends with an error.");
+                        
                         return new Status(STATUS_INVALID_AUTH_TOKEN);
+                    
+                    } catch (VerificationException e) {
+                        LOG.error("VerificationException", e);
+                        
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("JwtVerifyHandler.execute ends with an error.");
+                        
+                        return new Status(STATUS_INVALID_AUTH_TOKEN);
+                    
                     }
                 } else {
                     if (LOG.isDebugEnabled())


### PR DESCRIPTION
Issue: JwtVerifier would throw VerificationException whenever there are scenarios when there are no JWK available for requests' jwt's kid. However, it would still proceed to forward the request to downstream lambda even with the error.

Sample error: 
```
14:37:39.778 [main]   ERROR c.n.aws.lambda.LightLambdaExchange:268 updateExchangeStatus - Exchange has an error in the request phase.
LambdaNativeAuditLog {"timestamp":1751351852977,"X-Correlation-Id":"W4R6J5LLSsy6FD1VO8hwkA","X-Traceability-Id":"123-123-123","serviceId":"com.networknt.placeholder-1.0.0","statusCode":400,"responseTime":6802,"endpoint":"/api/{api-version}/zoloz/id-recognition/initialize@post"}
14:37:39.781 [main]   ERROR c.n.aws.lambda.LightLambdaExchange:222 getFinalizedResponse - Exchange has an error, returning middleware status.
14:37:39.786 [main]   DEBUG c.networknt.aws.lambda.app.LambdaApp:56 handleRequest - Lambda CCC --end with response: {statusCode: 500,headers: {Content-Type=application/json},body: {"statusCode":500,"code":"ERR14004","message":"MIDDLEWARE_UNHANDLED_EXCEPTION","description":"Middleware thread unhandled runtime exception.","severity":"ERROR"}}
{statusCode: 500,headers: {Content-Type=application/json},body: {"statusCode":500,"code":"ERR14004","message":"MIDDLEWARE_UNHANDLED_EXCEPTION","description":"Middleware thread unhandled runtime exception.","severity":"ERROR"}}
```

The error response is taken when testing on local machine, but when tested on AWS itself, the call would proceed to backend lambda, and if successful, the backend lambda's 200 OK response will be the one that the consumer application will receive.

Added VerificationException as one of the handled exception for cases such as no kid or kid mismatch between jwt and jwk. This would halt the request and return 401.