### PR TITLE
LambdaProxyMiddleware Client Configuration Options

### DIFF
--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyConfig.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyConfig.java
@@ -7,6 +7,9 @@ public class LambdaProxyConfig {
     private boolean enabled;
     private String region;
     private String endpointOverride;
+    private int readTimeout;
+    private int writeTimeout;
+    private int connectionTimeout;
     private int apiCallAttemptTimeout;
     private int apiCallTimeout;
     private int maxRetryAttempts;
@@ -39,6 +42,30 @@ public class LambdaProxyConfig {
         this.endpointOverride = endpointOverride;
     }
 
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public int getWriteTimeout() {
+        return writeTimeout;
+    }
+
+    public void setWriteTimeout(int writeTimeout) {
+        this.writeTimeout = writeTimeout;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
     public int getApiCallAttemptTimeout() {
         return apiCallAttemptTimeout;
     }
@@ -53,6 +80,14 @@ public class LambdaProxyConfig {
 
     public void setApiCallTimeout(int apiCallTimeout) {
         this.apiCallTimeout = apiCallTimeout;
+    }
+
+    public int getMaxRetryAttempts() {
+        return maxRetryAttempts;
+    }
+
+    public void setMaxRetryAttempts(int maxRetryAttempts) {
+        this.maxRetryAttempts = maxRetryAttempts;
     }
 
     public String getLogType() {
@@ -86,5 +121,4 @@ public class LambdaProxyConfig {
     public void setMetricsName(String metricsName) {
         this.metricsName = metricsName;
     }
-
 }

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddleware.java
@@ -29,9 +29,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LambdaProxyMiddleware implements MiddlewareHandler {
     private static LambdaAsyncClient client;
+    private static final AtomicBoolean CLIENT_SETUP = new AtomicBoolean(false);
     private static final Logger LOG = LoggerFactory.getLogger(LambdaProxyMiddleware.class);
     private static AbstractMetricsMiddleware metricsMiddleware;
 
@@ -39,35 +41,61 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
     public static final String EXCHANGE_HAS_FAILED_STATE = "ERR10087";
 
     public static final LambdaProxyConfig CONFIG = (LambdaProxyConfig) Config.getInstance().getJsonObjectConfig(LambdaProxyConfig.CONFIG_NAME, LambdaProxyConfig.class);
-
     static final Map<String, PathTemplateMatcher<String>> methodToMatcherMap = new HashMap<>();
 
     public LambdaProxyMiddleware() {
-        SdkAsyncHttpClient asyncHttpClient = NettyNioAsyncHttpClient.builder()
-                .readTimeout(Duration.ofMillis(CONFIG.getApiCallAttemptTimeout()))
-                .writeTimeout(Duration.ofMillis(CONFIG.getApiCallAttemptTimeout()))
-                .connectionTimeout(Duration.ofMillis(CONFIG.getApiCallAttemptTimeout()))
-                .build();
-        ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
-                .apiCallTimeout(Duration.ofMillis(CONFIG.getApiCallTimeout()))
-                .apiCallAttemptTimeout(Duration.ofSeconds(CONFIG.getApiCallAttemptTimeout()))
-                .build();
-
-        var builder = LambdaAsyncClient.builder().region(Region.of(CONFIG.getRegion()))
-                        .httpClient(asyncHttpClient)
-                        .overrideConfiguration(overrideConfig);
-        if (!StringUtils.isEmpty(CONFIG.getEndpointOverride()))
-            builder.endpointOverride(URI.create(CONFIG.getEndpointOverride()));
-        client = builder.build();
-
-        if(CONFIG.isMetricsInjection()) lookupMetricsMiddleware();
+        if (getClient() != null) {
+            LOG.debug("LambdaAsyncClient initialized.");
+        }
+        if (CONFIG.isMetricsInjection()) lookupMetricsMiddleware();
         populateMethodToMatcherMap(CONFIG.getFunctions());
         if (LOG.isInfoEnabled()) LOG.info("LambdaProxyMiddleware is constructed");
     }
 
+    private static LambdaAsyncClient getClient() {
+        if (CLIENT_SETUP.compareAndExchange(false, true)) {
+
+            /* Create our netty client */
+            var readTimeout = CONFIG.getReadTimeout();
+            var writeTimeout = CONFIG.getWriteTimeout();
+            var connectionTimeout = CONFIG.getConnectionTimeout();
+            LOG.debug("Creating 'SdkAsyncHttpClient' with readTimeout = '{}ms' writeTimeout = '{}ms' connectionTimeout = '{}ms'",
+                    readTimeout,
+                    writeTimeout,
+                    connectionTimeout
+            );
+            SdkAsyncHttpClient asyncHttpClient = NettyNioAsyncHttpClient.builder()
+                    .readTimeout(Duration.ofMillis(readTimeout))
+                    .writeTimeout(Duration.ofMillis(writeTimeout))
+                    .connectionTimeout(Duration.ofMillis(connectionTimeout))
+                    .build();
+
+            /* Add some override properties */
+            var apiCallTimeout = CONFIG.getApiCallTimeout();
+            var apiCallAttemptTimeout = CONFIG.getApiCallAttemptTimeout();
+            LOG.debug("Creating 'ClientOverrideConfiguration' with apiCallTimeout = '{}ms' apiCallAttemptTimeout = '{}ms'",
+                    apiCallTimeout,
+                    apiCallAttemptTimeout
+            );
+            ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
+                    .apiCallTimeout(Duration.ofMillis(apiCallTimeout))
+                    .apiCallAttemptTimeout(Duration.ofMillis(apiCallAttemptTimeout))
+                    .build();
+
+            /* Build lambda client using the netty client and additional configuration */
+            var builder = LambdaAsyncClient.builder().region(Region.of(CONFIG.getRegion()))
+                    .httpClient(asyncHttpClient)
+                    .overrideConfiguration(overrideConfig);
+            if (!StringUtils.isEmpty(CONFIG.getEndpointOverride()))
+                builder.endpointOverride(URI.create(CONFIG.getEndpointOverride()));
+            client = builder.build();
+        }
+        return client;
+    }
+
     @Override
     public Status execute(LightLambdaExchange exchange) {
-        if(LOG.isTraceEnabled()) LOG.trace("LambdaProxyMiddleware.execute starts.");
+        if (LOG.isTraceEnabled()) LOG.trace("LambdaProxyMiddleware.execute starts.");
         if (!exchange.hasFailedState()) {
             /* invoke lambda function */
             var path = exchange.getRequest().getPath();
@@ -79,8 +107,8 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
                 return new Status(FAILED_TO_INVOKE_LAMBDA, path + "@" + method);
             }
             var functionName = result.getValue();
-            if(LOG.isTraceEnabled()) LOG.trace("Function name: {}", functionName);
-            var res = this.invokeFunction(client, functionName, exchange);
+            if (LOG.isTraceEnabled()) LOG.trace("Function name: {}", functionName);
+            var res = this.invokeFunction(getClient(), functionName, exchange);
             if (res == null) {
                 LOG.error("Failed to invoke lambda function: {}", functionName);
                 return new Status(FAILED_TO_INVOKE_LAMBDA, functionName);
@@ -88,7 +116,7 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
             LOG.debug("Invoke Time - Finish: {}", System.currentTimeMillis());
             var responseEvent = JsonMapper.fromJson(res, APIGatewayProxyResponseEvent.class);
             exchange.setInitialResponse(responseEvent);
-            if(LOG.isTraceEnabled()) LOG.trace("LambdaProxyMiddleware.execute ends.");
+            if (LOG.isTraceEnabled()) LOG.trace("LambdaProxyMiddleware.execute ends.");
             return this.successMiddlewareStatus();
         } else {
             LOG.error("Exchange has failed state {}", exchange.getState());
@@ -102,7 +130,7 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
             var path = endpoint.split("@")[0];
             var method = endpoint.split("@")[1];
             PathTemplateMatcher<String> matcher = methodToMatcherMap.computeIfAbsent(method, k -> new PathTemplateMatcher<>());
-            if(matcher.get(path) == null) matcher.add(path, entry.getValue());
+            if (matcher.get(path) == null) matcher.add(path, entry.getValue());
             methodToMatcherMap.put(method, matcher);
         }
     }
@@ -119,9 +147,9 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
             long startTime = System.nanoTime();
             CompletableFuture<String> futureResponse = client.invoke(request)
                     .thenApply(res -> {
-                        if(CONFIG.isMetricsInjection()) {
-                            if(metricsMiddleware == null) lookupMetricsMiddleware();
-                            if(metricsMiddleware != null) {
+                        if (CONFIG.isMetricsInjection()) {
+                            if (metricsMiddleware == null) lookupMetricsMiddleware();
+                            if (metricsMiddleware != null) {
                                 if (LOG.isTraceEnabled()) LOG.trace("Inject metrics for {}", CONFIG.getMetricsName());
                                 metricsMiddleware.injectMetrics(exchange, startTime, CONFIG.getMetricsName(), null);
                             }
@@ -134,8 +162,11 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
                         return null;
                     });
             return futureResponse.get();
-        } catch (InterruptedException | ExecutionException e) {
-            LOG.error("LambdaException", e);
+        } catch (ExecutionException e) {
+            LOG.error("ExecutionException", e);
+        } catch (InterruptedException e) {
+            LOG.error("InterruptedException", e);
+            Thread.currentThread().interrupt();
         }
         return null;
     }
@@ -184,7 +215,7 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
         // get the metrics middleware instance from the chain.
         Map<String, LambdaHandler> handlers = Handler.getHandlers();
         metricsMiddleware = (AbstractMetricsMiddleware) handlers.get(MetricsConfig.CONFIG_NAME);
-        if(metricsMiddleware == null) {
+        if (metricsMiddleware == null) {
             LOG.error("An instance of MetricsMiddleware is not configured in the handler.yml file.");
         }
     }

--- a/src/main/resources/config/lambda-proxy.yml
+++ b/src/main/resources/config/lambda-proxy.yml
@@ -12,6 +12,12 @@ endpointOverride: ${lambda-proxy.endpointOverride:}
 apiCallTimeout: ${lambda-proxy.apiCallTimeout:60000}
 # Api call attempt timeout in milliseconds. This sets the amount of time for each individual attempt.
 apiCallAttemptTimeout: ${lambda-proxy.apiCallAttemptTimeout:20000}
+# The amount of time to wait for a read socket. 0 to disable.
+readTimeout: ${lambda-proxy.readTimeout:60000}
+# The amount of time to wait for a write socket. 0 to disable.
+writeTimeout: ${lambda-proxy.writeTimeout:60000}
+# The amount of time to wait when trying to establish a connection.
+connectionTimeout: ${lambda-proxy.connectionTimeout:}
 # log type for the lambda function invocation
 logType: ${lambda-proxy.logType:Tail}
 # When LambdaFunctionInvoker is used to invoke the downstream Lambda Function, it can collect the metrics info


### PR DESCRIPTION
## Changes
- Moved static assignments out of LambdaProxyMiddleware constructor.
- Added new configuration properties for readTimeout, writeTimeout, and connectionTimeout.
- Added more logging during client creation.


## Fixes
- Changed apiCallAttemptTimeout to millis instead of seconds.
- Added additional catches for thread interrupts when making async calls to the downstream.