### PR TITLE
Normalize The HTTP Method When Building The Route Table

### DIFF
--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddleware.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -104,7 +105,7 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
         if (!exchange.hasFailedState()) {
             /* invoke lambda function */
             var path = exchange.getRequest().getPath();
-            var method = exchange.getRequest().getHttpMethod().toLowerCase();
+            var method = normalizeMethod(exchange.getRequest().getHttpMethod());
             LOG.debug("Request path: {} -- Request method: {} -- Start time: {}", path, method, System.currentTimeMillis());
             var functionName = resolveFunctionName(path, method);
             if (functionName == null) {
@@ -154,15 +155,30 @@ public class LambdaProxyMiddleware implements MiddlewareHandler {
     private void populateMethodToMatcherMap(final Map<String, String> functions) {
         this.methodToMatcherMap.clear();
         for (var entry : functions.entrySet()) {
-            var endpoint = entry.getKey().split("@");
-            var path = endpoint[0];
-            var method = endpoint[1];
+            var endpoint = entry.getKey();
+            var separatorIndex = endpoint.lastIndexOf('@');
+            if (separatorIndex < 1 || separatorIndex == endpoint.length() - 1) {
+                LOG.error("Skipping lambda-proxy function '{}': the key must use the 'path@method' format.", endpoint);
+                continue;
+            }
+            var path = endpoint.substring(0, separatorIndex);
+            var method = normalizeMethod(endpoint.substring(separatorIndex + 1));
             PathTemplateMatcher<String> matcher = this.methodToMatcherMap.computeIfAbsent(method,
                     k -> new PathTemplateMatcher<>());
             if (matcher.get(path) == null)
                 matcher.add(path, entry.getValue());
-            this.methodToMatcherMap.put(method, matcher);
         }
+    }
+
+    /**
+     * Normalizes an HTTP method to lower case so that the route table built from the configuration
+     * and the lookup performed for an incoming request always agree on the key.
+     *
+     * @param method the HTTP method to normalize
+     * @return the method in lower case
+     */
+    private static String normalizeMethod(final String method) {
+        return method.toLowerCase(Locale.ROOT);
     }
 
     private String invokeFunction(

--- a/src/test/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddlewareTest.java
+++ b/src/test/java/com/networknt/aws/lambda/handler/middleware/proxy/LambdaProxyMiddlewareTest.java
@@ -9,6 +9,7 @@ import com.networknt.status.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -90,5 +91,58 @@ public class LambdaProxyMiddlewareTest {
         Status status = Assertions.assertDoesNotThrow(
                 () -> middleware.execute(exchangeFor("/v1/unknown", "GET")));
         Assertions.assertEquals(LambdaProxyMiddleware.FAILED_TO_INVOKE_LAMBDA, status.getCode());
+    }
+
+    /**
+     * The route table is keyed by the configured method and looked up with the request method, so both
+     * sides must agree on case. An upper case configuration key used to register a route that no
+     * request could ever reach.
+     */
+    @Test
+    public void testUpperCaseConfiguredMethodStillRoutes() {
+        var middleware = new LambdaProxyMiddleware(Map.of("/v1/pets@GET", "PetsGetFunction"));
+        Assertions.assertEquals("PetsGetFunction", middleware.resolveFunctionName("/v1/pets", "get"));
+    }
+
+    @Test
+    public void testMixedCaseConfiguredMethodStillRoutes() {
+        var middleware = new LambdaProxyMiddleware(Map.of("/v1/pets@Delete", "PetsDeleteFunction"));
+        Assertions.assertEquals("PetsDeleteFunction", middleware.resolveFunctionName("/v1/pets", "delete"));
+    }
+
+    /**
+     * The request method is upper case on the wire, so an upper case configuration key must be
+     * reachable through the same normalization {@code execute} applies before the lookup.
+     */
+    @Test
+    public void testUpperCaseConfiguredMethodIsReachableByAnUpperCaseRequest() {
+        var middleware = new LambdaProxyMiddleware(Map.of("/v1/pets@POST", "PetsPostFunction"));
+        var exchange = exchangeFor("/v1/pets", "POST");
+        var method = exchange.getRequest().getHttpMethod().toLowerCase(java.util.Locale.ROOT);
+        Assertions.assertEquals("PetsPostFunction",
+                middleware.resolveFunctionName(exchange.getRequest().getPath(), method));
+    }
+
+    /**
+     * A path containing '@' must still split on the separator before the method rather than the first
+     * '@' in the key.
+     */
+    @Test
+    public void testPathContainingSeparatorIsSplitOnTheLastSeparator() {
+        var middleware = new LambdaProxyMiddleware(Map.of("/v1/users/{user@domain}@get", "UserGetFunction"));
+        Assertions.assertEquals("UserGetFunction", middleware.resolveFunctionName("/v1/users/a@b.com", "get"));
+    }
+
+    @Test
+    public void testMalformedConfigurationKeysAreSkippedWithoutFailingStartup() {
+        var functions = new HashMap<String, String>();
+        functions.put("/v1/pets", "MissingMethodFunction");
+        functions.put("@get", "MissingPathFunction");
+        functions.put("/v1/pets@", "EmptyMethodFunction");
+        functions.put("/v1/pets@get", "PetsGetFunction");
+
+        var middleware = Assertions.assertDoesNotThrow(() -> new LambdaProxyMiddleware(functions));
+        Assertions.assertEquals("PetsGetFunction", middleware.resolveFunctionName("/v1/pets", "get"),
+                "a malformed entry must not prevent the valid entries from being registered");
     }
 }


### PR DESCRIPTION
Fixes #175.

> **Stacked on #177.** The base branch is #177, not `master`, because the #175 fix cannot be tested without the seam #177 introduces — `LambdaProxyMiddleware`'s only constructor builds a real `LambdaAsyncClient`. Please merge #177 first; GitHub will retarget this to `master` automatically. The diff shown here is only this change.

## The bug

The route table was keyed by the raw method from configuration, while lookups used the lower cased request method:

```java
var method = exchange.getRequest().getHttpMethod().toLowerCase();  // lookup: "get"
var method = endpoint[1];                                          // registration: "GET"
```

So `/v1/pets@GET` registered a route that no request could ever reach. Before #174 this surfaced as an NPE; since #174 it fails as a clean `ERR10086`, which is correct handling for a routing miss but makes the misconfiguration silent — the route is simply dead.

## Changes

- **`normalizeMethod`** applied on both registration and lookup, so the two sides cannot drift again.
- **`Locale.ROOT`** rather than the default locale. `OPTIONS` contains an `I`, so under a Turkish default locale `toLowerCase()` yields `optıons` with a dotless i and the route breaks. This is why the helper exists rather than just adding `.toLowerCase()` at the registration site.
- **Split on the last `@`** instead of every `@`, so a path containing the separator still parses.
- **Malformed keys are skipped with a logged error** instead of throwing `ArrayIndexOutOfBoundsException` during construction. A single bad entry taking down every invocation of the proxy seemed the worse failure mode, but say the word if you would rather fail fast at startup.
- **Dropped the redundant `put`** — `computeIfAbsent` already inserts and the matcher is mutated in place.

## Verification

The five new tests were run against the pre-fix source and all fail with exactly the reported symptoms:

```
testUpperCaseConfiguredMethodStillRoutes:104            expected: <PetsGetFunction> but was: <null>
testMixedCaseConfiguredMethodStillRoutes:110            expected: <PetsDeleteFunction> but was: <null>
testUpperCaseConfiguredMethodIsReachableByAnUpperCaseRequest:122
                                                        expected: <PetsPostFunction> but was: <null>
testMalformedConfigurationKeysAreSkippedWithoutFailingStartup:144
                            ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
testPathContainingSeparatorIsSplitOnTheLastSeparator:132 » Runtime
```

With the fix: `Tests run: 84, Failures: 0, Errors: 0, Skipped: 4` — 79 from #177, 5 added. `BUILD SUCCESS`, `git diff --check` clean.

## Compatibility

Existing all-lowercase configurations are unaffected — `values.yml` in the test resources already uses lowercase, and the full suite passes unchanged. Configurations that currently use upper or mixed case will start routing where they previously returned `ERR10086`. That is the intent of the fix, but it is a behaviour change worth calling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)