### PR TITLE
ALB Serialization Fix

### DIFF
--- a/src/main/java/com/networknt/aws/lambda/handler/cache/CacheExplorerHandler.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/cache/CacheExplorerHandler.java
@@ -39,12 +39,14 @@ public class CacheExplorerHandler implements LambdaHandler {
                 var res = new APIGatewayProxyResponseEvent()
                         .withStatusCode(200)
                         .withHeaders(headers)
+                        .withIsBase64Encoded(false)
                         .withBody(JsonMapper.toJson((map)));
                 exchange.setInitialResponse(res);
             } else {
                 var res = new APIGatewayProxyResponseEvent()
                         .withStatusCode(200)
                         .withHeaders(headers)
+                        .withIsBase64Encoded(false)
                         .withBody(JsonMapper.toJson((cacheMap)));
                 exchange.setInitialResponse(res);
             }
@@ -53,6 +55,7 @@ public class CacheExplorerHandler implements LambdaHandler {
             var res = new APIGatewayProxyResponseEvent()
                     .withStatusCode(status.getStatusCode())
                     .withHeaders(headers)
+                    .withIsBase64Encoded(false)
                     .withBody(status.toString());
             exchange.setInitialResponse(res);
         }

--- a/src/main/java/com/networknt/aws/lambda/handler/info/ServerInfoHandler.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/info/ServerInfoHandler.java
@@ -32,6 +32,7 @@ public class ServerInfoHandler implements LambdaHandler {
             var res = new APIGatewayProxyResponseEvent()
                     .withStatusCode(200)
                     .withHeaders(headers)
+                    .withIsBase64Encoded(false)
                     .withBody(JsonMapper.toJson((infoMap)));
 
             exchange.setInitialResponse(res);
@@ -42,6 +43,7 @@ public class ServerInfoHandler implements LambdaHandler {
             var res = new APIGatewayProxyResponseEvent()
                     .withStatusCode(status.getStatusCode())
                     .withHeaders(headers)
+                    .withIsBase64Encoded(false)
                     .withBody(status.toString());
             exchange.setInitialResponse(res);
             return status;

--- a/src/main/java/com/networknt/aws/lambda/handler/logger/LoggerGetHandler.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/logger/LoggerGetHandler.java
@@ -50,6 +50,7 @@ public class LoggerGetHandler implements LambdaHandler {
             var res = new APIGatewayProxyResponseEvent()
                     .withStatusCode(200)
                     .withHeaders(headers)
+                    .withIsBase64Encoded(false)
                     .withBody(JsonMapper.toJson((loggersList)));
             exchange.setInitialResponse(res);
         } else {

--- a/src/main/java/com/networknt/aws/lambda/handler/logger/LoggerSetHandler.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/logger/LoggerSetHandler.java
@@ -45,6 +45,7 @@ public class LoggerSetHandler implements LambdaHandler {
                 var res = new APIGatewayProxyResponseEvent()
                         .withStatusCode(200)
                         .withHeaders(headers)
+                        .withIsBase64Encoded(false)
                         .withBody(JsonMapper.toJson(loggers));
                 exchange.setInitialResponse(res);
             }

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/ExceptionUtil.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/ExceptionUtil.java
@@ -39,6 +39,8 @@ public class ExceptionUtil {
                 responseEvent.setIsBase64Encoded(false);
                 return responseEvent;
             }
-        return new APIGatewayProxyResponseEvent();
+        var defaultResponseEvent = new APIGatewayProxyResponseEvent();
+        defaultResponseEvent.setIsBase64Encoded(false);
+        return defaultResponseEvent;
     }
 }

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/cors/RequestCorsMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/cors/RequestCorsMiddleware.java
@@ -91,6 +91,7 @@ public class RequestCorsMiddleware implements MiddlewareHandler {
 
     private Status handlePreflightRequest(LightLambdaExchange exchange, List<String> allowedOrigins, List<String> allowedMethods) {
         APIGatewayProxyResponseEvent responseEvent = new APIGatewayProxyResponseEvent();
+        responseEvent.setIsBase64Encoded(false);
         Map<String, String> requestHeaders = exchange.getRequest().getHeaders();
         Map<String, String> responseHeaders = new HashMap<>();
         if (MapUtil.getValueIgnoreCase(requestHeaders, ORIGIN).isPresent()) {

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/router/LambdaRouterMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/router/LambdaRouterMiddleware.java
@@ -109,6 +109,7 @@ public class LambdaRouterMiddleware implements MiddlewareHandler {
                         APIGatewayProxyResponseEvent res = new APIGatewayProxyResponseEvent()
                                 .withStatusCode(response.statusCode())
                                 .withHeaders(convertJdkHeaderToMap(response.headers().map()))
+                                .withIsBase64Encoded(false)
                                 .withBody(response.body());
                         if (config.isMetricsInjection()) {
                             if (metricsMiddleware == null)
@@ -138,6 +139,7 @@ public class LambdaRouterMiddleware implements MiddlewareHandler {
                         APIGatewayProxyResponseEvent res = new APIGatewayProxyResponseEvent()
                                 .withStatusCode(response.statusCode())
                                 .withHeaders(convertJdkHeaderToMap(response.headers().map()))
+                                .withIsBase64Encoded(false)
                                 .withBody(response.body());
                         if (config.isMetricsInjection()) {
                             if (metricsMiddleware == null)

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/security/BasicAuthMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/security/BasicAuthMiddleware.java
@@ -112,6 +112,7 @@ public class BasicAuthMiddleware implements MiddlewareHandler {
                 headers.put(HeaderKey.WWW_AUTHENTICATE, "Basic realm=\"Default Realm\"");
                 responseEvent.setHeaders(headers);
                 responseEvent.setStatusCode(status.getStatusCode());
+                responseEvent.setIsBase64Encoded(false);
                 responseEvent.setBody(status.toString());
                 exchange.setInitialResponse(responseEvent);
                 if(LOG.isDebugEnabled()) LOG.debug("BasicAuthMiddleware.execute ends with an error.");
@@ -126,6 +127,7 @@ public class BasicAuthMiddleware implements MiddlewareHandler {
             headers.put(HeaderKey.WWW_AUTHENTICATE, "Basic realm=\"Basic Auth\"");
             responseEvent.setHeaders(headers);
             responseEvent.setStatusCode(status.getStatusCode());
+            responseEvent.setIsBase64Encoded(false);
             responseEvent.setBody(status.toString());
             exchange.setInitialResponse(responseEvent);
             if(LOG.isDebugEnabled()) LOG.debug("BasicAuthMiddleware.execute ends with an error.");

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/security/UnifiedSecurityMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/security/UnifiedSecurityMiddleware.java
@@ -76,6 +76,7 @@ public class UnifiedSecurityMiddleware implements MiddlewareHandler {
                                 headers.put(HeaderKey.WWW_AUTHENTICATE, "Basic realm=\"Default Realm\"");
                                 responseEvent.setHeaders(headers);
                                 responseEvent.setStatusCode(status.getStatusCode());
+                                responseEvent.setIsBase64Encoded(false);
                                 responseEvent.setBody(status.toString());
                                 exchange.setInitialResponse(responseEvent);
                                 if (LOG.isDebugEnabled())

--- a/src/main/java/com/networknt/aws/lambda/handler/middleware/transformer/RequestTransformerMiddleware.java
+++ b/src/main/java/com/networknt/aws/lambda/handler/middleware/transformer/RequestTransformerMiddleware.java
@@ -173,6 +173,7 @@ public class RequestTransformerMiddleware extends AbstractTransformerMiddleware 
                                             headers.put(HeaderKey.CONTENT_TYPE, HeaderValue.APPLICATION_JSON);
                                             responseEvent.setHeaders(headers);
                                             responseEvent.setStatusCode(Objects.requireNonNullElse((Integer) result.get("statusCode"), 200));
+                                            responseEvent.setIsBase64Encoded(false);
                                             responseEvent.setBody(responseBody);
                                             exchange.setInitialResponse(responseEvent);
                                             break;


### PR DESCRIPTION
- Added explicit isBase64Encoded (false) values for all returned APIGatewayProxyResponseEvent responses.
- This will prevent `"isBase64Encoded": null` from being added to the payload when compiled using GraalVM.